### PR TITLE
Improvements to mobile client - use medium size image (#73)

### DIFF
--- a/src/Cloud/ContosoMoments.API/Controllers/TableControllers/ImageStorageController.cs
+++ b/src/Cloud/ContosoMoments.API/Controllers/TableControllers/ImageStorageController.cs
@@ -18,8 +18,12 @@ namespace ContosoMoments.Api
         [Route("tables/Image/{id}/StorageToken")]
         // return a storage token that can be used for blob upload or download
         public async Task<HttpResponseMessage> PostStorageTokenRequest(string id, StorageTokenRequest request)
-        {            
-            StorageToken token = await GetStorageTokenAsync(id, request, new ImageNameResolver(request.TargetFile.StoreUri));
+        {
+            // The file size is encoded in the start of the filename, lg, md, etc.
+            // If it doesn't match the pattern then the default size of lg is used
+            var requestedSize = request.TargetFile.Name.Substring(0, 2); 
+
+            StorageToken token = await GetStorageTokenAsync(id, request, new ImageNameResolver(requestedSize));
             return Request.CreateResponse(token);
         }
 
@@ -28,16 +32,11 @@ namespace ContosoMoments.Api
         [Route("tables/Image/{id}/MobileServiceFiles")]
         public async Task<HttpResponseMessage> GetFiles(string id)
         {
-            IEnumerable<MobileServiceFile> files = await GetRecordFilesAsync(id, new ImageNameResolver());
+            var files = await GetRecordFilesAsync(id, new ImageNameResolver());      
+
             return Request.CreateResponse(files);
         }
 
-        [HttpDelete]
-        [Route("tables/Image/{id}/MobileServiceFiles/{name}")]
-        [Authorize]
-        public Task Delete(string id, string name)
-        {
-            return base.DeleteFileAsync(id, name, new ImageNameResolver());
-        }
+        // there's no Delete method, because deletion is handled by deleting the image itself
     }
 }

--- a/src/Cloud/ContosoMoments.API/Helpers/CustomAzureStorageProvider.cs
+++ b/src/Cloud/ContosoMoments.API/Helpers/CustomAzureStorageProvider.cs
@@ -26,7 +26,7 @@ namespace ContosoMoments.Api
             var result = await blob.ExistsAsync() ? new[] { blob } : Enumerable.Empty<CloudBlockBlob>();
 
             return result;
-        }
+        }        
 
         internal static string GetConnectionString(string connectionStringName = Constants.StorageConnectionStringName)
         {

--- a/src/Cloud/ContosoMoments.API/app/js/services/ImageService.js
+++ b/src/Cloud/ContosoMoments.API/app/js/services/ImageService.js
@@ -35,11 +35,13 @@ contosoMomentsApp
         return {
             getImageURL: function (imgId, imgSize) {
                 var defered = $q.defer();
+                var prefix = imgSize == "lg" ? "" : imgSize + "-";
+
                 $http.post('/tables/Image/' + imgId + '/StorageToken', {
                     "Permissions": "Read",
                     "TargetFile": {
-                        "Id": imgId,
-                        "Name": imgId,
+                        "Id": prefix + imgId,
+                        "Name": prefix + imgId,
                         "TableName": "Image",
                         "ParentId": imgId,
                         "ContentMD5": null,
@@ -51,7 +53,7 @@ contosoMomentsApp
                     "ProviderName": null
                 })
                 .then(function (res) {
-                    defered.resolve(res.data.ResourceUri.concat("/", res.data.EntityId, res.data.RawToken));
+                    defered.resolve(res.data.ResourceUri.concat("/", prefix, res.data.EntityId, res.data.RawToken));
                 })
                 .catch(function (err) {
                     console.log(err);

--- a/src/Cloud/ContosoMoments.API/app/templates/singleimage.html
+++ b/src/Cloud/ContosoMoments.API/app/templates/singleimage.html
@@ -5,7 +5,6 @@
     </div>
     <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3">
         <ul class="links-list">
-            <li class="icon-link"><a data-resolvesas="{{imageCtrl.currentImage.id}}" data-size="lg" href="" target="_blank" >Large Image</a></li>
             <li class="icon-link"><a data-resolvesas="{{imageCtrl.currentImage.id}}" data-size="md" href="" target="_blank" >Medium Image</a></li>
             <li class="icon-link"><a data-resolvesas="{{imageCtrl.currentImage.id}}" data-size="sm" href="" target="_blank" >Small Image</a></li>
             <li class="icon-link"><a data-resolvesas="{{imageCtrl.currentImage.id}}" data-size="xs" href="" target="_blank" >Extra small Image</a></li>

--- a/src/Cloud/ContosoMoments.Function/ResizeImage/function.json
+++ b/src/Cloud/ContosoMoments.Function/ResizeImage/function.json
@@ -8,19 +8,19 @@
             "direction": "InOut"
         },
         {
-            "path": "images-sm/{name}",
+            "path": "images-sm/sm-{name}",
             "type": "blob",
             "name": "blobOutputSmall",
             "direction": "InOut"
         },
         {
-            "path": "images-md/{name}",
+            "path": "images-md/md-{name}",
             "type": "blob",
             "name": "blobOutputMedium",
             "direction": "InOut"
         },
         {
-            "path": "images-xs/{name}",
+            "path": "images-xs/xs-{name}",
             "type": "blob",
             "name": "blobOutputExtraSmall",
             "direction": "InOut"

--- a/src/Cloud/ContosoMoments.ResizerWebJob/Functions.cs
+++ b/src/Cloud/ContosoMoments.ResizerWebJob/Functions.cs
@@ -15,9 +15,9 @@ namespace ContosoMoments.ResizerWebJob
             public string ImageId { get; set; }
 
             public const string ImageNameLg = "images-lg/{ImageId}";
-            public const string ImageNameMd = "images-md/{ImageId}";
-            public const string ImageNameSm = "images-sm/{ImageId}";
-            public const string ImageNameXs = "images-xs/{ImageId}";
+            public const string ImageNameMd = "images-md/md-{ImageId}";
+            public const string ImageNameSm = "images-sm/sm-{ImageId}";
+            public const string ImageNameXs = "images-xs/xs-{ImageId}";
         }
 
         private static Dictionary<ImageSize, ResizeSettings> imageDimensionsTable = new Dictionary<ImageSize, ResizeSettings>()

--- a/src/Mobile/ContosoMoments.Droid/ContosoMoments.Droid.csproj
+++ b/src/Mobile/ContosoMoments.Droid/ContosoMoments.Droid.csproj
@@ -233,6 +233,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomImageRenderer.cs" />
     <Compile Include="DroidPlatform.cs" />
     <Compile Include="GcmService.cs" />
     <Compile Include="MainActivity.cs" />

--- a/src/Mobile/ContosoMoments.Droid/CustomImageRenderer.cs
+++ b/src/Mobile/ContosoMoments.Droid/CustomImageRenderer.cs
@@ -1,0 +1,88 @@
+using System.ComponentModel;
+using Android.Graphics;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+using ContosoMoments.Droid;
+using ContosoMoments.Views;
+
+[assembly: ExportRenderer(typeof(CustomImage), typeof(CustomImageRenderer))]
+namespace ContosoMoments.Droid
+{
+    // This custom render resizes bitmaps in memory before displaying them.
+    // The Xamarin.Forms image control uses memory proportional to the image dimensions on Android,
+    // so you will get an out of memory error with only a few images if they have large dimensions.
+    // See https://developer.xamarin.com/recipes/android/resources/general/load_large_bitmaps_efficiently/
+
+    public class CustomImageRenderer : ImageRenderer
+    {
+        protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
+        {
+            base.OnElementChanged(e);
+        }
+
+        private bool isScaled;
+
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            base.OnElementPropertyChanged(sender, e);
+
+            var customImage = (CustomImage)Element;
+
+            if ((!isScaled || e.PropertyName == "ImageSource") && customImage.ImageSource?.Length > 0) {
+
+                var options = GetBitmapOptionsOfImage(customImage.ImageSource);
+
+                // resize to the element dimensions
+                var width = (int)customImage.Width;
+                var height = (int)customImage.Height;
+                options.InSampleSize = CalculateInSampleSize(options, width, height);
+
+                // Decode bitmap with inSampleSize set
+                options.InJustDecodeBounds = false;
+
+                var bitmap = BitmapFactory.DecodeFile(customImage.ImageSource, options);
+
+                //Set the bitmap to the native control
+                Control.SetImageBitmap(bitmap);
+
+                isScaled = true;
+            }
+
+        }
+
+        private static BitmapFactory.Options GetBitmapOptionsOfImage(string filename)
+        {
+            BitmapFactory.Options options = new BitmapFactory.Options {
+                InJustDecodeBounds = true
+            };
+
+            // The result will be null because InJustDecodeBounds == true.
+            Bitmap result = BitmapFactory.DecodeFile(filename, options);
+
+            int imageHeight = options.OutHeight;
+            int imageWidth = options.OutWidth;
+
+            return options;
+        }
+
+        public static int CalculateInSampleSize(BitmapFactory.Options options, int reqWidth, int reqHeight)
+        {
+            // Raw height and width of image
+            float height = options.OutHeight;
+            float width = options.OutWidth;
+            double inSampleSize = 1D;
+
+            if (height > reqHeight || width > reqWidth) {
+                int halfHeight = (int)(height / 2);
+                int halfWidth = (int)(width / 2);
+
+                // Calculate a inSampleSize that is a power of 2 - the decoder will use a value that is a power of two anyway.
+                while ((halfHeight / inSampleSize) > reqHeight && (halfWidth / inSampleSize) > reqWidth) {
+                    inSampleSize *= 2;
+                }
+            }
+
+            return (int)inSampleSize;
+        }
+    }
+}

--- a/src/Mobile/ContosoMoments.iOS/TouchPlatform.cs
+++ b/src/Mobile/ContosoMoments.iOS/TouchPlatform.cs
@@ -71,7 +71,7 @@ namespace ContosoMoments.iOS
             var user = GetCachedUser();
 
             if (user == null) {
-                var view = UIApplication.SharedApplication.KeyWindow.RootViewController;
+                var view = GetTopViewController();
                 user = await App.Instance.MobileService.LoginAsync(view, provider);
             }
 
@@ -84,8 +84,8 @@ namespace ContosoMoments.iOS
 
             tcs = new TaskCompletionSource<MobileServiceUser>();
             var loginManager = new LoginManager();
-            var view = UIApplication.SharedApplication.KeyWindow.RootViewController;
-
+            var view = GetTopViewController();
+           
             var user = GetCachedUser();
 
             if (user != null) {
@@ -117,6 +117,18 @@ namespace ContosoMoments.iOS
 
             AuthStore.DeleteTokenCache();
             await App.Instance.MobileService.LogoutAsync();
+        }
+
+        private UIViewController GetTopViewController()
+        {
+            var view = UIApplication.SharedApplication.KeyWindow.RootViewController;
+
+            // Find the view controller that's currently on top. This is required if there's a modal page being displayed
+            while (view.PresentedViewController != null) {
+                view = view.PresentedViewController;
+            }
+
+            return view;
         }
 
         private async void LoginTokenHandler(LoginManagerLoginResult loginResult, NSError error)

--- a/src/Mobile/ContosoMoments/App.cs
+++ b/src/Mobile/ContosoMoments/App.cs
@@ -92,15 +92,18 @@ namespace ContosoMoments
 
             if (showLoginDialog) {
                 await Utils.PopulateDefaultsAsync();
-                MainPage = new NavigationPage(new AlbumsListView());
 
                 await DoLoginAsync();
+
+                Debug.WriteLine("*** DoLoginAsync complete");
+
+                MainPage = new NavigationPage(new AlbumsListView());
             }
             else {
-                MainPage = new NavigationPage(new AlbumsListView());
-
                 // user has already chosen an authentication type, so re-authenticate
                 await AuthHandler.DoLoginAsync(Settings.Current.AuthenticationType);
+
+                MainPage = new NavigationPage(new AlbumsListView());
             }
         }
 
@@ -115,7 +118,7 @@ namespace ContosoMoments
         private async Task DoLoginAsync()
         {
             var loginPage = new Login();
-            await MainPage.Navigation.PushAsync(loginPage);
+            await MainPage.Navigation.PushModalAsync(loginPage);
             Settings.Current.AuthenticationType = await loginPage.GetResultAsync();
 
             await SyncAsync(notify: true);
@@ -138,7 +141,7 @@ namespace ContosoMoments
             await albumTableSync.PurgeAsync(AllAlbumsQueryString, null, true, CancellationToken.None);
 
             // delete downloaded files
-            await FileHelper.DeleteLocalFileAsync(await platform.GetDataFilesPath());
+            await FileHelper.DeleteLocalPathAsync(await platform.GetDataFilesPath());
 
             Settings.Current.AuthenticationType = Settings.AuthOption.GuestAccess;
             Settings.Current.CurrentUserId = Settings.Current.DefaultUserId;

--- a/src/Mobile/ContosoMoments/AuthHandler.cs
+++ b/src/Mobile/ContosoMoments/AuthHandler.cs
@@ -59,7 +59,7 @@ namespace ContosoMoments
 
             var user =
                 authOption == Settings.AuthOption.Facebook ?
-                    await mobileClient.LoginFacebookAsync() :
+                    await LoginFacebookAsync(mobileClient) :
                     await mobileClient.LoginAsync(MobileServiceAuthenticationProvider.WindowsAzureActiveDirectory);
 
             App.Instance.AuthenticatedUser = user;
@@ -74,6 +74,14 @@ namespace ContosoMoments
             Debug.WriteLine($"Set current userID to: {Settings.Current.CurrentUserId}");
 
             AuthStore.CacheAuthToken(user);
+        }
+
+        private static Task<MobileServiceUser> LoginFacebookAsync(IPlatform mobileClient)
+        {
+            // use server flow if the service URL has been customized
+            return Settings.IsDefaultServiceUrl() ?
+                mobileClient.LoginFacebookAsync() :
+                mobileClient.LoginAsync(MobileServiceAuthenticationProvider.Facebook);
         }
 
         private async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request)

--- a/src/Mobile/ContosoMoments/ContosoMoments.projitems
+++ b/src/Mobile/ContosoMoments/ContosoMoments.projitems
@@ -31,6 +31,7 @@
       <DependentUpon>AlbumsListView.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Views\CustomImage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\ImageDetailsView.xaml.cs">
       <DependentUpon>ImageDetailsView.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/src/Mobile/ContosoMoments/Helpers/FileHelper.cs
+++ b/src/Mobile/ContosoMoments/Helpers/FileHelper.cs
@@ -39,20 +39,26 @@ namespace ContosoMoments
             return System.IO.Path.Combine(recordFilesPath, fileName);
         }
 
-        public static async Task DeleteLocalFileAsync(string fullPath)
+        public static async Task DeleteLocalPathAsync(string fullPath)
         {
             var checkExists = await FileSystem.Current.LocalStorage.CheckExistsAsync(fullPath);
 
-            if (checkExists == ExistenceCheckResult.FileExists) {
-                var file = await FileSystem.Current.LocalStorage.GetFileAsync(fullPath);
-                await file.DeleteAsync();
+            if (checkExists == ExistenceCheckResult.FolderExists) {
+                var folder = await FileSystem.Current.LocalStorage.GetFolderAsync(fullPath);
+                await folder.DeleteAsync();
             }
         }
 
         public static async Task DeleteLocalFileAsync(Microsoft.WindowsAzure.MobileServices.Files.MobileServiceFile fileName, string dataFilesPath)
         {
             string localPath = await GetLocalFilePathAsync(fileName.ParentId, fileName.Name, dataFilesPath);
-            await DeleteLocalFileAsync(localPath);
+
+            var checkExists = await FileSystem.Current.LocalStorage.CheckExistsAsync(localPath);
+
+            if (checkExists == ExistenceCheckResult.FileExists) {
+                var file = await FileSystem.Current.LocalStorage.GetFileAsync(localPath);
+                await file.DeleteAsync();
+            }
         }
     }
 }

--- a/src/Mobile/ContosoMoments/Helpers/Settings.cs
+++ b/src/Mobile/ContosoMoments/Helpers/Settings.cs
@@ -18,6 +18,11 @@ namespace ContosoMoments
             return Current.DefaultUserId == UserIdDefault;
         }
 
+        public static bool IsDefaultServiceUrl()
+        {
+            return Current.MobileAppUrl == DefaultMobileAppUrl;
+        }
+
         public enum AuthOption
         {
             GuestAccess, Facebook, ActiveDirectory

--- a/src/Mobile/ContosoMoments/ViewModels/ImagesListViewModel.cs
+++ b/src/Mobile/ContosoMoments/ViewModels/ImagesListViewModel.cs
@@ -23,6 +23,8 @@ namespace ContosoMoments.ViewModels
             this.app = app;
 
             DeleteCommand = new DelegateCommand(OnDeleteAlbum, AlbumsListViewModel.IsRenameAndDeleteEnabled);
+
+            eventSubscription = app.MobileService.EventManager.Subscribe<ImageDownloadEvent>(DownloadStatusObserver);
         }
 
         #region Properties
@@ -82,8 +84,6 @@ namespace ContosoMoments.ViewModels
                         im.ImageLoaded = await FileSystem.Current.LocalStorage.CheckExistsAsync(filePath) == ExistenceCheckResult.FileExists;
                     }
                 }
-
-                eventSubscription = app.MobileService.EventManager.Subscribe<ImageDownloadEvent>(DownloadStatusObserver);
             }
             catch (Exception ex) {
                 ErrorMessage = ex.Message;

--- a/src/Mobile/ContosoMoments/Views/CustomImage.cs
+++ b/src/Mobile/ContosoMoments/Views/CustomImage.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using Xamarin.Forms;
+
+namespace ContosoMoments.Views
+{
+    public class CustomImage : Image
+    {
+        public static readonly BindableProperty ImageSourceProperty =
+            BindableProperty.Create(
+                "ImageSource", typeof(string),
+                typeof(CustomImage), default(string), propertyChanged: OnImageSourcePropertyChanged);
+
+
+        private static void OnImageSourcePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+        {
+            if (Device.OS != TargetPlatform.Android) {
+                var image = (CustomImage)bindable; // use default behavior on non-Android platforms
+
+                var baseImage = (Image)bindable;
+                baseImage.Source = image.ImageSource;
+            }
+        }
+
+        public string ImageSource
+        {
+            get { return GetValue(ImageSourceProperty) as string; }
+            set { SetValue(ImageSourceProperty, value); }
+        }
+    }
+}

--- a/src/Mobile/ContosoMoments/Views/ImagesList.xaml
+++ b/src/Mobile/ContosoMoments/Views/ImagesList.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:ContosoMoments.Views;assembly=ContosoMoments"
              x:Class="ContosoMoments.Views.ImagesList"
              BackgroundColor="#8C0A4B">
 
@@ -60,7 +61,7 @@
                 <ColumnDefinition Width="50"/>
                 <ColumnDefinition Width="*"/>
               </Grid.ColumnDefinitions>
-              <Image Grid.Column="0" Source="{Binding Uri}" Aspect="AspectFill" />
+              <local:CustomImage Grid.Column="0" ImageSource="{Binding Uri}" Aspect="AspectFill" />
               <ContentView Grid.Column="1" Padding="10,0,0,0">
                 <Label Text="{Binding ImageInfo}" FontSize="Small" TextColor="Black" VerticalTextAlignment="Center"/>
               </ContentView>

--- a/src/Mobile/ContosoMoments/Views/ImagesList.xaml.cs
+++ b/src/Mobile/ContosoMoments/Views/ImagesList.xaml.cs
@@ -22,8 +22,8 @@ namespace ContosoMoments.Views
             // allow image upload to the public album with the default service only if logged in with AAD
             bool showImageUpload =
                 !album.IsDefault ||
-                (Settings.Current.MobileAppUrl == Settings.DefaultMobileAppUrl &&
-                    Settings.Current.AuthenticationType == Settings.AuthOption.ActiveDirectory);
+                (!Settings.IsDefaultServiceUrl() ||
+                 Settings.Current.AuthenticationType == Settings.AuthOption.ActiveDirectory);
 
             imgUpload.IsVisible = showImageUpload;
 

--- a/src/Mobile/ContosoMoments/Views/Login.xaml.cs
+++ b/src/Mobile/ContosoMoments/Views/Login.xaml.cs
@@ -42,7 +42,7 @@ namespace ContosoMoments.Views
         {
             DependencyService.Get<IPlatform>().LogEvent("Login" + option);
 
-            await Navigation.PopToRootAsync();
+            await Navigation.PopModalAsync();
 
             tcs.TrySetResult(option);
         }


### PR DESCRIPTION
* Mobile client: add custom image renderer for Android, to reduce memory usage

* Mobile client: use Facebook server flow if not using the default service URL

* Mobile client: change login to modal; show albums page only after login

* Cloud project: use image size prefix on resized images

* Update web client to use images with a size prefix

* Mobile client: fix bug in clearing image cache on logout

* Mobile client: fix code to show new image button if not using default service